### PR TITLE
Fix workflow push permissions

### DIFF
--- a/.github/workflows/daily_weather.yml
+++ b/.github/workflows/daily_weather.yml
@@ -1,5 +1,8 @@
 name: Daily Weather
 
+permissions:
+  contents: write
+
 on:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
## Summary
- allow the daily_weather workflow to push changes by granting contents write permissions

## Testing
- `python -m py_compile weather.py`


------
https://chatgpt.com/codex/tasks/task_e_684a10f6cff083279dc5b4d4adf6546d